### PR TITLE
Splat operator

### DIFF
--- a/features.js
+++ b/features.js
@@ -312,6 +312,22 @@ const features = [
         ]
     },
     {
+        name: 'Splat operator (... operator)',
+        description: 'The ... operator, aka the splat operator or array unpacking operator',
+        keywords: [
+            'spread', 'unpacking', 'arrays', 'splat'
+        ],
+        added: '5.6',
+        deprecated: null,
+        removed: null,
+        resources: [
+            {
+                name: 'Argument unpacking via ...',
+                url: 'https://www.php.net/manual/en/migration56.new-features.php#migration56.new-features.splat'
+            }
+        ]
+    },
+    {
         name: 'Multi catch exception handline',
         description: 'A catch block may specify multiple exceptions using the pipe (|) character',
         keywords: [

--- a/features.js
+++ b/features.js
@@ -312,7 +312,7 @@ const features = [
         ]
     },
     {
-        name: 'Splat operator (... operator)',
+        name: 'Splat operator / argument unpacking (... operator)',
         description: 'The ... operator, aka the splat operator or array unpacking operator',
         keywords: [
             'spread', 'unpacking', 'arrays', 'splat'


### PR DESCRIPTION
I added the documentation for the splat operator to go with the array unpacking feature. It may be useful to differentiate between the splat operator itself (Since 5.6) and the ability to use the splat operator to unpack in the context of an array declaration. 