### PR TITLE
Better array unpack research without ellipsis character

### DIFF
--- a/features.js
+++ b/features.js
@@ -17,7 +17,7 @@ const features = [
     },
     {
         name: 'Array unpacking with string keys',
-        description: 'e.g. <code>$result = [\'a\' => 0, …$arrayA, …$arrayB];</code>',
+        description: 'e.g. <code>$result = [\'a\' => 0, ...$arrayA, ...$arrayB];</code>',
         keywords: [
             'spread', 'unpacking', 'arrays', 'deconstruct'
         ],


### PR DESCRIPTION
Hi,

I suggest replacing the ellipsis character in the array unpack description to simplify research with it. I usually don't remember the names of this operators and I simply search by their representation like ?-> for the nullsafe of ... for the unpack but as on computer there's no auto replace for the ellipsis character as Android does on mobile, the research doesn't find the operator correctly.

Korko