### PR TITLE
Correct typo

### DIFF
--- a/features.js
+++ b/features.js
@@ -452,7 +452,7 @@ const features = [
     ],
   },
   {
-    name: "Multi catch exception handline",
+    name: "Multi catch exception handling",
     description:
       "A catch block may specify multiple exceptions using the pipe (|) character",
     keywords: ["exceptions"],


### PR DESCRIPTION
Fix typo of "exception handline" -> "exception handling"