### PR TITLE
Add `mixed` type

### DIFF
--- a/features.js
+++ b/features.js
@@ -323,6 +323,25 @@ const features = [
     ],
   },
   {
+    name: "mixed type",
+    description:
+      "`mixed` is equivalent to the union type `object|resource|array|string|int|float|bool|null`.",
+    keywords: ["declarations", "typehints", "return", "types"],
+    added: "8.0",
+    deprecated: null,
+    removed: null,
+    resources: [
+      {
+        name: "mixed type (php.net)",
+        url: "https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.mixed",
+      },
+      {
+        name: "PHP 8.0: New mixed pseudo type (php.watch)",
+        url: "PHP 8.0: New mixed pseudo type",
+      },
+    ],
+  },
+  {
     name: "Typed properties",
     description: "Class properties now support type declarations.",
     keywords: ["properties", "class", "types", "typehints"],
@@ -485,7 +504,7 @@ const features = [
     name: "void return type",
     description:
       "<code>void</code> is a return type indicating the function does not return a value.",
-    keywords: ["declarations", "typehints", "return"],
+    keywords: ["declarations", "typehints", "return", "types"],
     added: "7.1",
     deprecated: null,
     removed: null,
@@ -493,21 +512,6 @@ const features = [
       {
         name: "void return type (php.net)",
         url: "https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.return-only",
-      },
-    ],
-  },
-  {
-    name: "mixed type",
-    description:
-      "<code>mixed</code> is equivalent to the union type object|resource|array|string|int|float|bool|null.",
-    keywords: ["declarations", "typehints", "return"],
-    added: "8.0",
-    deprecated: null,
-    removed: null,
-    resources: [
-      {
-        name: "mixed type (php.net)",
-        url: "https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.mixed",
       },
     ],
   },

--- a/features.js
+++ b/features.js
@@ -497,6 +497,21 @@ const features = [
     ],
   },
   {
+    name: "mixed type",
+    description:
+      "<code>mixed</code> is equivalent to the union type object|resource|array|string|int|float|bool|null.",
+    keywords: ["declarations", "typehints", "return"],
+    added: "8.0",
+    deprecated: null,
+    removed: null,
+    resources: [
+      {
+        name: "mixed type (php.net)",
+        url: "https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.mixed",
+      },
+    ],
+  },
+  {
     name: "Group use declarations",
     description:
       "Classes, functions and constants being imported from the same namespace can be grouped together in a single use statement.",


### PR DESCRIPTION
This was added in PHP 8.0.

It's important to know when it came in because PHP 8.1 throws deprecations about method signatures requiring it. This means the approach to fixing those deprecations is very sensitive to desired supported versions.