### PR TITLE
feat: add background colour for deprecated features

### DIFF
--- a/dist/style.css
+++ b/dist/style.css
@@ -953,6 +953,11 @@ Ensure the default browser behavior of the `hidden` attribute.
   border-width: 1px;
 }
 
+.bg-amber-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(253 230 138 / var(--tw-bg-opacity));
+}
+
 .bg-green-300 {
   --tw-bg-opacity: 1;
   background-color: rgb(134 239 172 / var(--tw-bg-opacity));
@@ -1055,7 +1060,7 @@ Ensure the default browser behavior of the `hidden` attribute.
 }
 
 code {
-  font-family:'Courier New', Courier, monospace;
+  font-family: "Courier New", Courier, monospace;
   --tw-bg-opacity: 1;
   background-color: rgb(229 231 235 / var(--tw-bg-opacity));
   padding-top: 0.25rem;
@@ -1065,8 +1070,8 @@ code {
 }
 
 :root {
-  --color-blue-light: #8892BF;
-  --color-blue-dark: #4F5B93;
+  --color-blue-light: #8892bf;
+  --color-blue-dark: #4f5b93;
   --font: "Fira Sans", "Source Sans Pro", Helvetica, Arial, sans-serif;
 }
 

--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
                 <template x-for="version in versions">
                   <div
                     class="flex-1 px-3 py-2 text-center"
-                    :class="featureSupportedIn(feature, version.version) ? 'bg-green-300 font-bold' : 'bg-red-300'"
+                    :class="featureSupportedClass(feature, version.version)"
                   >
                     <span x-text="version.version"></span>
                   </div>
@@ -252,6 +252,19 @@
 
               // Feature is added and not removed
               return true;
+            },
+
+            featureSupportedClass(feature, version) {
+              if (
+                feature.deprecated !== null &&
+                this.versionCompare(feature.deprecated, version) <= 0
+              ) {
+                return "bg-amber-200";
+              }
+
+              return this.featureSupportedIn(feature, version)
+                ? "bg-green-300 font-bold"
+                : "bg-red-300";
             },
 
             filteredFeatures() {

--- a/index.html
+++ b/index.html
@@ -255,8 +255,11 @@
             },
 
             featureSupportedClass(feature, version) {
+              // Feature is deprecated, but not removed
               if (
                 feature.deprecated !== null &&
+                (feature.removed === null ||
+                  this.versionCompare(feature.removed, version) === 1) &&
                 this.versionCompare(feature.deprecated, version) <= 0
               ) {
                 return "bg-amber-200";

--- a/index.html
+++ b/index.html
@@ -254,13 +254,21 @@
               return true;
             },
 
+            featureIsDeprecatedIn(feature, version) {
+                return feature.deprecated !== null
+                    && this.versionCompare(feature.deprecated, version) <= 0;
+            },
+
+            featureIsRemovedIn(feature, version) {
+                return feature.removed !== null
+                    && this.versionCompare(feature.removed, version) <= 0;
+            },
+
             featureSupportedClass(feature, version) {
               // Feature is deprecated, but not removed
               if (
-                feature.deprecated !== null &&
-                (feature.removed === null ||
-                  this.versionCompare(feature.removed, version) === 1) &&
-                this.versionCompare(feature.deprecated, version) <= 0
+                this.featureIsDeprecatedIn(feature, version) &&
+                !this.featureIsRemovedIn(feature, version)
               ) {
                 return "bg-amber-200";
               }


### PR DESCRIPTION
This adds an amber (yellow-y) colour for deprecated features. I've attached a screenshot of how this looks below:

![Preview of how the colour looks](https://user-images.githubusercontent.com/1899334/167869767-10fb4b7b-d3ce-4760-b451-9f03db6d0bfd.png)
